### PR TITLE
Make tabs text more clear

### DIFF
--- a/src/app/pages/tabs/tabs.component.html
+++ b/src/app/pages/tabs/tabs.component.html
@@ -1,1 +1,1 @@
-<p>tabs works!</p>
+<p>Tabs just work! You just used them, on the left.</p>


### PR DESCRIPTION
There were grammatical mistakes in the tab text and the wording was overall unclear.